### PR TITLE
Adding usefull snippet of reference() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Variety of snippets to use with Microsoft Azure
 
 - [Alert on Azure API Management Failures for a specific API](alert-azure-api-management-failed-requests-per-api)
-- [Lookup the IP Address of API Management Feature after deployment](lookup-azure-api-management-instance-ip-address)
+- [Lookup the IP Address of Azure API Management after deployment](lookup-azure-api-management-instance-ip-address)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 Variety of snippets to use with Microsoft Azure
 
 - [Alert on Azure API Management Failures for a specific API](alert-azure-api-management-failed-requests-per-api)
+- [Lookup the IP Address of API Management Feature after deployment](lookup-azure-api-management-instance-ip-address)

--- a/lookup-azure-api-management-instance-ip-address/README.md
+++ b/lookup-azure-api-management-instance-ip-address/README.md
@@ -1,0 +1,49 @@
+# Lookup the IP Address for Azure API Management Instance
+
+## How does it work?
+In certain automated deployment (DevOps) scenarios, for example when you want to whitelist traffic from APIM only, you have the deployed resources (for example Logic Apps) automatically configured with the IP Address of the APIM Instance. This avoids having to manually reconfigure the IP address into all the required resources after deployment.
+
+Luckily, the Azure Resource Manager provides a function that can be used from ARM templates to lookup (or "reference") details from other resources during deployment.
+
+The **`reference()`** function allows you to retrieve the resource in the form of a JSON object and allows you to pick the specific properties that you are interested in:
+```
+reference(resourceId(variables('apimResourceGroup'),'Microsoft.ApiManagement/service/',variables('apimServiceName')),'2019-12-01','Full').properties.publicIPAddresses[0]
+```
+
+A cutdown response JSON object would look similar to the following (many other details omitted for clarity):
+```JSON
+{
+  ...
+  "properties": {
+    ...
+    "publicIPAddresses": [
+      "13.85.20.170"
+    ],
+    "privateIPAddresses": [
+      "192.168.1.5"
+    ],
+    ...
+  },
+  ...
+}
+```
+
+> You can use Rest API (or Azure Resource Explorer) to retrieve and inspect the JSON response object to see which properties are available
+> `GET https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.ApiManagement/service/<service-name>?api-version=<api-version>`
+
+An example of what this would look like in practice (for example: setting access control on a Logic App to whitelist the IP address) would be as follows:
+```JSON
+"accessControl": {
+  "triggers": {
+    "allowedCallerIpAddresses": [
+      {
+        "addressRange": "[concat(reference(resourceId(variables('apimResourceGroup'),'Microsoft.ApiManagement/service/',variables('apimServiceName')),'2019-12-01','Full').properties.publicIPAddresses[0],'/30')]"
+      }
+    ]
+  },
+  "actions": {
+    "allowedCallerIpAddresses": []
+  }
+}
+```
+> In the example above the Logic App expects a CIDR block or IP Address range which is why the "/30" subnet mask has been concatenated to the retrieved IP address.

--- a/lookup-azure-api-management-instance-ip-address/README.md
+++ b/lookup-azure-api-management-instance-ip-address/README.md
@@ -6,7 +6,8 @@ In certain automated deployment (DevOps) scenarios, for example when you want to
 
 Luckily, the Azure Resource Manager provides a function that can be used from ARM templates to lookup (or "reference") details from other resources during deployment.
 
-The **`reference()`** function allows you to retrieve the resource in the form of a JSON object and allows you to pick the specific properties that you are interested in:
+The **[`reference()`](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#reference)** function allows you to retrieve the resource in the form of a JSON object and allows you to pick the specific properties that you are interested in:
+
 ```
 reference(resourceId(variables('apimResourceGroup'),'Microsoft.ApiManagement/service/',variables('apimServiceName')),'2019-12-01','Full').properties.publicIPAddresses[0]
 ```

--- a/lookup-azure-api-management-instance-ip-address/README.md
+++ b/lookup-azure-api-management-instance-ip-address/README.md
@@ -1,7 +1,8 @@
 # Lookup the IP Address for Azure API Management Instance
 
 ## How does it work?
-In certain automated deployment (DevOps) scenarios, for example when you want to whitelist traffic from APIM only, you have the deployed resources (for example Logic Apps) automatically configured with the IP Address of the APIM Instance. This avoids having to manually reconfigure the IP address into all the required resources after deployment.
+In certain automated deployment (DevOps) scenarios, for example when you want to whitelist traffic from Azure API Management (APIM) only, you have the deployed resources (for example Logic Apps) automatically configured with the IP Address of the APIM Instance. This avoids having to manually reconfigure the IP address into all the required resources after deployment.
+
 
 Luckily, the Azure Resource Manager provides a function that can be used from ARM templates to lookup (or "reference") details from other resources during deployment.
 

--- a/lookup-azure-api-management-instance-ip-address/README.md
+++ b/lookup-azure-api-management-instance-ip-address/README.md
@@ -6,11 +6,10 @@ In certain automated deployment (DevOps) scenarios, for example when you want to
 
 Luckily, the Azure Resource Manager provides a function that can be used from ARM templates to lookup (or "reference") details from other resources during deployment.
 
-The **[`reference()`](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#reference)** function allows you to retrieve the resource in the form of a JSON object and allows you to pick the specific properties that you are interested in:
+The **[`reference()`](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#reference)** function allows you to retrieve the resource in the form of a JSON object and allows you to pick the specific properties that you are interested in.
 
-```
-reference(resourceId(variables('apimResourceGroup'),'Microsoft.ApiManagement/service/',variables('apimServiceName')),'2019-12-01','Full').properties.publicIPAddresses[0]
-```
+> Before using the `reference()` function, have a look at the JSON object for your resource. You can use Rest API (or the Azure Resource Explorer) to retrieve and inspect the JSON response object to see which properties are available
+> `GET https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.ApiManagement/service/<service-name>?api-version=<api-version>`
 
 A cutdown response JSON object would look similar to the following (many other details omitted for clarity):
 ```JSON
@@ -30,8 +29,12 @@ A cutdown response JSON object would look similar to the following (many other d
 }
 ```
 
-> You can use Rest API (or Azure Resource Explorer) to retrieve and inspect the JSON response object to see which properties are available
-> `GET https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.ApiManagement/service/<service-name>?api-version=<api-version>`
+From the response above, one can then determine the path of the required property and adjust the reference function to retrieve the property (for example: the `publicIPAddresses[0]` in this case).
+
+For example:
+```
+reference(resourceId(variables('apimResourceGroup'),'Microsoft.ApiManagement/service/',variables('apimServiceName')),'2019-12-01','Full').properties.publicIPAddresses[0]
+```
 
 An example of what this would look like in practice (for example: setting access control on a Logic App to whitelist the IP address) would be as follows:
 ```JSON


### PR DESCRIPTION
Adding usefull snippet of reference() function to show how to lookup the IP Address of an APIM instance during a deployment.